### PR TITLE
Add Let's Encrypt configuration and update ingress settings in values.yaml

### DIFF
--- a/letsencrypt-clusterissuer.yaml
+++ b/letsencrypt-clusterissuer.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com # CHANGE THIS TO YOUR EMAIL
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com # CHANGE THIS TO YOUR EMAIL
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/values.yaml
+++ b/values.yaml
@@ -57,14 +57,21 @@ service:
 # Ingress configuration for external access
 ingress:
   enabled: false # Set to true to enable ingress
-  className: "" # Ingress class (e.g., "nginx", "traefik")
-  annotations: {} # Additional ingress annotations
+  className: "nginx" # Ingress class (e.g., "nginx", "traefik")
+  annotations: 
+    # Let's Encrypt annotations for automatic SSL certificate provisioning
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # Use letsencrypt-staging for testing, letsencrypt-prod for production
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
     - host: chart-example.local # Change to your domain
       paths:
         - path: /
           pathType: Prefix
-  tls: [] # TLS configuration for HTTPS
+  tls: 
+    - secretName: inngest-tls # Secret name for TLS certificate
+      hosts:
+        - chart-example.local # Change to your domain
 
 # Resource limits and requests for the main Inngest container
 # IMPORTANT: Set appropriate limits for production use


### PR DESCRIPTION
This pull request introduces comprehensive updates to enable HTTPS with Let's Encrypt for Kubernetes ingress configurations. The changes include detailed instructions, new YAML templates, and updates to configuration files to streamline automatic SSL certificate provisioning.

### Documentation Enhancements:
- **Updated `README.md`**: Added a new section on setting up HTTPS with Let's Encrypt, including prerequisites, installation steps for `cert-manager`, and troubleshooting SSL certificates.
- **Clarified annotations**: Updated the `cert-manager.io/cluster-issuer` annotation description to emphasize its requirement for automatic Let's Encrypt certificates.

### Configuration Updates:
- **Ingress settings in `values.yaml`**: Modified ingress configuration to include annotations for Let's Encrypt, specify the ingress class (`nginx`), and define TLS settings with a secret name for certificates.

### New YAML Templates:
- **Added `letsencrypt-clusterissuer.yaml`**: Provided templates for both production (`letsencrypt-prod`) and staging (`letsencrypt-staging`) ClusterIssuers to facilitate SSL certificate provisioning.