### PR TITLE
Allow extra environment variables to be added

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -90,6 +90,11 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          # Extra environment variables from values
+          {{- with .Values.inngest.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           # Load configuration from ConfigMap and secrets
           envFrom:
             # Non-sensitive configuration (ports, log levels, etc.)

--- a/values.yaml
+++ b/values.yaml
@@ -154,6 +154,19 @@ inngest:
   sqlite:
     dir: "" # SQLite directory path (INNGEST_SQLITE_DIR)
 
+  # Extra environment variables to pass to the Inngest container
+  # Useful for setting env vars supported by future versions of Inngest
+  # Example:
+  #   extraEnv:
+  #     - name: INNGEST_CUSTOM_VAR
+  #       value: "custom-value"
+  #     - name: INNGEST_SECRET_VAR
+  #       valueFrom:
+  #         secretKeyRef:
+  #           name: my-secret
+  #           key: secret-key
+  extraEnv: []
+
 # Internal PostgreSQL database configuration
 # Set enabled: false to use external PostgreSQL (configure inngest.postgres.uri)
 postgresql:


### PR DESCRIPTION
The extraEnv option enables developers to add custom environment variables or future environment variables that are not currently available as configuration options in their helm chart version. This removes the need for someone updating the helm chart to take advantage of a new server env variable option.